### PR TITLE
Fix template for windows

### DIFF
--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -6,7 +6,7 @@
 <%= key %>='<%= value %>'
 <% end %>
 
-Chef::Config.from_file('/etc/chef/client.rb')
+Chef::Config.from_file(PathHelper.join(Chef::Config.platform_specific_path("/etc/chef/"), "client.rb"))
 
 # The whitelist comes from node['push_jobs']['whitelist']
 whitelist(<%= @whitelist.to_hash.inspect %>)


### PR DESCRIPTION
On windows systems the /etc/chef/client.rb path doesn't make sense. This attempts to leverage platform_specific_path to do better.

Not necessarily the best at ruby/windows integration, so I'd love feedback. Needs testing before it's mergeable. 

@jtimberman @smurawski  