### PR TITLE
Add a retries to the service

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/recipes/service_runit.rb
+++ b/recipes/service_runit.rb
@@ -23,4 +23,6 @@ include_recipe 'runit'
 runit_service 'opscode-push-jobs-client' do
   default_logger true
   subscribes :restart, "template[#{PushJobsHelper.config_path}]"
+  action [ :enable, :start ]
+  retries 15
 end

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'push-jobs::linux' do
-  let(:chef_run) do
-    runner = ChefSpec::Runner.new(platform: 'ubuntu', version: '10.04')
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
     runner.converge('recipe[push-jobs::config]')
   end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe 'push-jobs::default' do
   context 'Ubuntu' do
-    let(:chef_run) do
-      runner = ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04')
+    cached(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04')
       runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_x86_64.deb?key=value'
       runner.converge('recipe[push-jobs::default]')
     end
 
     it 'Does not raise an incompatibility error' do
-      expect(chef_run).not_to raise_error
+      expect { chef_run }.not_to raise_error
     end
 
     it 'Includes the linux recipe' do
@@ -18,14 +18,14 @@ describe 'push-jobs::default' do
   end
 
   context 'Windows' do
-    let(:chef_run) do
-      runner = ChefSpec::Runner.new(platform: 'windows', version: '2008R2')
+    cached(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2')
       runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_x86_64.msi?key=value'
       runner.converge('recipe[push-jobs::default]')
     end
 
     it 'Does not raise an incompatibility error' do
-      expect(chef_run).not_to raise_error
+      expect { chef_run }.not_to raise_error
     end
 
     it 'Includes the Windows recipe' do

--- a/spec/unit/recipes/knife_spec.rb
+++ b/spec/unit/recipes/knife_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'push-jobs::knife' do
-  let(:chef_run) do
-    runner = ChefSpec::Runner.new
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new
     runner.node.set['push_jobs']['gem_url'] = 'http://foo.bar.com/knife-pushy-0.1.gem?key=value'
     runner.converge('recipe[push-jobs::knife]')
   end

--- a/spec/unit/recipes/linux_spec.rb
+++ b/spec/unit/recipes/linux_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'push-jobs::linux' do
-  let(:chef_run) do
-    runner = ChefSpec::Runner.new(platform: 'ubuntu', version: '10.04')
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
     runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_amd64.deb?key=value'
     runner.node.set['push_jobs']['whitelist'] = { 'chef-client' => 'chef-client' }
     runner.converge('recipe[push-jobs::linux]')
@@ -22,8 +22,8 @@ describe 'push-jobs::linux' do
   end
 
   it 'starts the opscode-push-jobs-client' do
-    pending 'Write a custom matcher for the runit_service definition'
-    expect(chef_run).to start_service 'opscode-push-jobs-client'
+    expect(chef_run).to start_runit_service 'opscode-push-jobs-client'
+    expect(chef_run).to enable_runit_service 'opscode-push-jobs-client'
   end
 
 end

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -2,15 +2,14 @@ require 'spec_helper'
 
 describe 'push-jobs::windows' do
 
-  let(:chef_run) do
-    runner = ChefSpec::Runner.new(platform: 'windows', version: '2008R2')
+  cached(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2')
     runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_x86_64.msi?key=value'
     runner.node.set['push_jobs']['whitelist'] = { 'chef-client' => 'chef-client' }
     runner.converge('recipe[push-jobs::windows]')
   end
 
   it 'Installs the MSI file' do
-    pending 'Extend the package matcher for Windows_package'
     display_name = 'Opscode Push Jobs Client Installer for Windows'
     expect(chef_run).to install_windows_package "#{display_name}"
   end
@@ -20,7 +19,6 @@ describe 'push-jobs::windows' do
   end
 
   it 'Configures the pushy-client registry key' do
-    pending 'Write a custom matcher for registry_key'
     expect(chef_run).to create_registry_key('HKLM\\SYSTEM\\CurrentControlSet\\Services\\pushy-client')
   end
 


### PR DESCRIPTION
The runit service often fails to start/restart due to timeouts. This
simply extends the number of times we try - since the runit command is
itself idempotent, it should make us much more resiliant aginst
failures.

Also, I updated the test suite to run with the latest ChefDK.
Integration tests are completely non functional, but they appear to
always have been.
