### PR TITLE
Add CentOS 7.1 to the test matrix and verify that it works

### DIFF
--- a/.kitchen.local.yml.example
+++ b/.kitchen.local.yml.example
@@ -1,27 +1,35 @@
 ---
+provisioner:
+  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
+
 platforms:
 - name: ubuntu-14.04
   attributes:
     push_jobs:
-      package_url: "http://example.com/push-jobs-client-1.0.0-1.deb"
-      package_checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      package_url: https://packagecloud.io/chef/stable/packages/ubuntu/precise/opscode-push-jobs-client_1.1.5-1_amd64.deb/download
+      package_checksum: d7b40ebb18c7c7dbc32322c9bcd721279e707fd1bee3609a37055838afbf67ea
 - name: ubuntu-12.04
   attributes:
     push_jobs:
-      package_url: "http://example.com/push-jobs-client-1.0.0-1.deb"
-      package_checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      package_url: https://packagecloud.io/chef/stable/packages/ubuntu/precise/opscode-push-jobs-client_1.1.5-1_amd64.deb/download
+      package_checksum: d7b40ebb18c7c7dbc32322c9bcd721279e707fd1bee3609a37055838afbf67ea
 - name: ubuntu-10.04
   attributes:
     push_jobs:
-      package_url: "http://example.com/push-jobs-client-1.0.0-1.deb"
-      package_checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-- name: centos-6.4
+      package_url: https://packagecloud.io/chef/stable/packages/ubuntu/lucid/opscode-push-jobs-client_1.1.5-1_amd64.deb/download
+      package_checksum: 0a8f5069b7281f5acb800290d2e18b766864d46597fc84548f14a17a5b437426
+- name: centos-7.1
   attributes:
     push_jobs:
-      package_url: "http://example.com/push-jobs-client-1.0.0-1.rpm"
-      package_checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-- name: centos-5.10
+      package_url: https://packagecloud.io/chef/stable/packages/el/6/opscode-push-jobs-client-1.1.5-1.el6.x86_64.rpm/download
+      package_checksum: f5e6be32f60b689e999dcdceb102371a4ab21e5a1bb6fb69ff4b2243a7185d84
+- name: centos-6.6
   attributes:
     push_jobs:
-      package_url: "http://example.com/push-jobs-client-1.0.0-1.rpm"
-      package_checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      package_url: https://packagecloud.io/chef/stable/packages/el/6/opscode-push-jobs-client-1.1.5-1.el6.x86_64.rpm/download
+      package_checksum: f5e6be32f60b689e999dcdceb102371a4ab21e5a1bb6fb69ff4b2243a7185d84
+- name: centos-5.11
+  attributes:
+    push_jobs:
+      package_url: https://packagecloud.io/chef/stable/packages/el/5/opscode-push-jobs-client-1.1.5-1.el5.x86_64.rpm/download
+      package_checksum: 753fa40c3282612a9a26b6690669c06e5c76cfee261842ef3e4ad78b5e524d2c

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ platforms:
 - name: ubuntu-14.04
 - name: ubuntu-12.04
 - name: ubuntu-10.04
+- name: centos-7.1
 - name: centos-6.4
 - name: centos-5.10
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.3.0'
 
 # Tested on Ubuntu 14.04, 12.04, 10.04
-# Tested on CentOS 6.4, 5.10
+# Tested on CentOS 7.1, 6.6, 5.11
 supports 'ubuntu'
 supports 'centos'
 supports 'debian'

--- a/test/integration/default/serverspec/localhost/linux_spec.rb
+++ b/test/integration/default/serverspec/localhost/linux_spec.rb
@@ -11,7 +11,7 @@ describe 'push-jobs::default recipe' do
     expect(file '/etc/chef/push-jobs-client.rb').to be_owned_by('root')
     expect(file '/etc/chef/push-jobs-client.rb').to be_grouped_into('root')
     expect(file '/etc/chef/push-jobs-client.rb').to contain('whitelist({"chef-client"=>"chef-client"})')
-    expect(file '/etc/chef/push-jobs-client.rb').to contain('LC_ALL=en_US.UTF-8')
+    expect(file '/etc/chef/push-jobs-client.rb').to contain("LC_ALL='en_US.UTF-8'")
   end
 
 end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,11 +1,5 @@
 require 'serverspec'
 require 'pathname'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
-RSpec.configure do |c|
-  c.before :all do
-    c.os = backend(Serverspec::Commands::Base).check_os
-  end
-end


### PR DESCRIPTION
* Chef 12 now requires valid checksums.  I updated the `.kitchen.local.yml.example` to point at the 1.1.5 packages on packagecloud and added valid checksums for all
  * we should change this in the future to use chef-ingredient
* Include CentOS 7.1 in the testing matrix
* Fix serverspec tests - all platforms now pass

fixes #22 

