### PR TITLE
use chef-ingredient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # push-jobs cookbook
 
-Installs the Chef Push Jobs client package and sets it up to run as
+Installs the Chef Push client package and sets it up to run as
 a service.
 
 The official documentation is on
-[docs.getchef.com](http://docs.opscode.com/push_jobs.html)
+[docs.chef.io](http://docs.chef.io/push_jobs.html)
 
 # Requirements
 
-Requires Enterprise Chef with the Push
-Jobs feature.
+Requires Chef Server with the Chef Push
+Server add-on.
 
 * Chef: 11.4.0 or higher
-* runit cookbook
-* windows cookbook
+* [runit](https://supermarket.chef.io/cookbooks/runit)
+* [windows](https://supermarket.chef.io/cookbooks/windows)
+* [chef-ingredient](https://supermarket.chef.io/cookbooks/chef-ingredient)
 
 ## Platform
 
@@ -29,20 +30,14 @@ Testing for Ubuntu/CentOS can be done with Test Kitchen, see TESTING.md in this 
 
 # Usage
 
-Set the appropriate attributes and include the default recipe in a
-node's run list. The URL to the package to install and its SHA256
-checksum are required so the package may be retrieved. For example:
+Include the default recipe in a node's run list. On Windows, the URL to the package to install and its SHA256 checksum are required so the package may be retrieved. For example:
 
-    node.set['push_jobs']['package_url'] = "http://www.example.com/pkgs/opscode-push-jobs-client_1.0.1-1.ubuntu.12.04_amd64.deb"
-    node.set['push_jobs']['package_checksum'] = "a-sha256-checksum"
+    node.default['push_jobs']['package_url'] = "http://www.example.com/pkgs/opscode-push-jobs-client-windows-1.1.5-1.windows.msi"
+    node.default['push_jobs']['package_checksum'] = "a-sha256-checksum"
 
-In order for the push jobs to be used, a whitelist of job names and
-their commands must be set in the configuration file. This is
-automatically generated from the attribute
-`node['push_jobs']['whitelist']`. This attribute must be a Hash. For
-example:
+Set a whitelist of job names and their commands in the configuration file. This is automatically generated from the `node['push_jobs']['whitelist']` attribute Hash, such as:
 
-    node.set['push_jobs']['whitelist'] = {
+    node.default['push_jobs']['whitelist'] = {
       "chef-client" => "chef-client",
       "apt-get-update" => "apt-get update"
     }
@@ -84,7 +79,7 @@ together (include the `default` recipe), or as necessary.
 The default recipe includes the appropriate recipe based on the node's
 `platform_family`. It will `raise` an error if:
 
-- The package URL and checksum attributes are not set.
+- The package URL and checksum attributes are not set on Windows
 - The whitelist is not a Hash.
 - The node's platform is not supported.
 
@@ -107,8 +102,7 @@ file path is used on Linux and Windows platforms, as it uses
 
 ## linux
 
-The `node['push_jobs']['package_url']` attribute must be set for this
-recipe to download the Chef Push Jobs Client package from the URL.
+This recipe downloads and installs the Chef Push client from CHEF's public repositories. Setting the `node['push_jobs']['package_version']` attribute installs a specific version from the public repositories. Setting the `node['push_jobs']['package_url']` and `node['push_jobs']['package_checksum']` attributes together will override the default behavior and download the package from the specified URL.
 
 ## knife
 
@@ -124,16 +118,15 @@ This recipe is responsible for handling the service resource based on
 the node's platform. On Linux (Debian and RHEL families), it will
 create a `runit` service. The default logger is used, and the log will
 be `/var/log/push-jobs-client/current`. On Windows, it will add a
-registry key for the Push Jobs client, and manage the Windows service.
+registry key for the Chef Push client, and manage the Windows service.
 
 The service resources expect to be restarted if the configuration
 template is changed, using `subscribes` notification.
 
 ## windows
 
-The `node['push_jobs']['package_url']` attribute must be set
-to use this recipe, as Windows does not have the concept of a package
-manager with remote repositories. The URL will be used (with the
+The `node['push_jobs']['package_url']` and `node['push_jobs']['package_checksum']` attributes must be set
+to use this recipe. The URL will be used (with the
 checksum attribute) to install the package using the `windows_package`
 resource from the `windows` cookbook.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 
 default['push_jobs']['package_url']                 = nil
 default['push_jobs']['package_checksum']            = ''
+default['push_jobs']['package_version']             = nil
 default['push_jobs']['gem_url']                     = nil
 default['push_jobs']['gem_checksum']                = ''
 default['push_jobs']['whitelist']                   = { 'chef-client' => 'chef-client' }

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ supports 'windows'
 # For per-platform resources, respectively
 depends 'runit'
 depends 'windows'
+depends 'chef-ingredient'
 
 attribute('push_jobs/package_url',
           :description => 'URL to a client package to download
@@ -24,6 +25,9 @@ attribute('push_jobs/package_url',
 attribute('push_jobs/package_checksum',
           :description => 'Checksum of the package file from package_url,
           use this to prevent download every Chef run')
+
+attribute('push_jobs/package_version',
+	      :description => 'Version of the package to be installed')
 
 attribute('push_jobs/gem_url',
           :description => 'URL to the knife plugin gem file')

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,16 +20,15 @@
 # limitations under the License.
 #
 
-unless (node['push_jobs']['package_url'] && node['push_jobs']['package_checksum'])
-  raise "Please specify ['push_jobs']['package_url'] and ['push_jobs']['package_checksum'] attributes."
-end
-
 unless (node['push_jobs']['whitelist'].is_a? Hash)
   raise "node['push_jobs']['whitelist'] should have a hash value!"
 end
 
 case node['platform_family']
 when 'windows'
+  unless (node['push_jobs']['package_url'] && node['push_jobs']['package_checksum'])
+    raise "Please set both ['push_jobs']['package_url'] and ['push_jobs']['package_checksum'] attributes."
+  end
   include_recipe 'push-jobs::windows'
 when 'debian', 'rhel'
   include_recipe 'push-jobs::linux'

--- a/spec/unit/recipes/linux_spec.rb
+++ b/spec/unit/recipes/linux_spec.rb
@@ -1,29 +1,61 @@
 require 'spec_helper'
 
 describe 'push-jobs::linux' do
-  cached(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
-    runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_amd64.deb?key=value'
-    runner.node.set['push_jobs']['whitelist'] = { 'chef-client' => 'chef-client' }
-    runner.converge('recipe[push-jobs::linux]')
+  context 'windows' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012')
+      runner.converge('recipe[push-jobs::linux]')
+    end
+
+    it 'Raises an incompatibility error' do
+      expect { chef_run }.to raise_error 'This recipe does not support Windows'
+    end
   end
 
-  it 'fetches the push jobs package' do
-    package_file = 'opscode-push-jobs-client_amd64.deb'
-    expect(chef_run).to create_remote_file "#{Chef::Config[:file_cache_path]}/#{package_file}"
+  context 'linux with package_url' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
+      runner.node.set['push_jobs']['package_url'] = 'http://foo.bar.com/opscode-push-jobs-client_amd64.deb?key=value'
+      runner.converge('recipe[push-jobs::linux]')
+    end
+
+    before { @package_file = 'opscode-push-jobs-client_amd64.deb' }
+
+    it 'fetches the push jobs package' do
+      expect(chef_run).to create_remote_file "#{Chef::Config[:file_cache_path]}/#{@package_file}"
+    end
+
+    it 'installs the chef_ingredient push-client' do
+      expect(chef_run).to install_chef_ingredient('push-client').with(package_source: "#{Chef::Config[:file_cache_path]}/#{@package_file}")
+    end
+
+    it 'includes the config recipe' do
+      expect(chef_run).to include_recipe("#{described_cookbook}::config")
+    end
+
+    it 'starts the opscode-push-jobs-client' do
+      expect(chef_run).to start_runit_service 'opscode-push-jobs-client'
+      expect(chef_run).to enable_runit_service 'opscode-push-jobs-client'
+    end
   end
 
-  it 'installs the push jobs package' do
-    expect(chef_run).to install_package 'opscode-push-jobs-client'
-  end
+  context 'linux without package_url' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '10.04')
+      runner.converge('recipe[push-jobs::linux]')
+    end
 
-  it 'includes the config recipe' do
-    expect(chef_run).to include_recipe("#{described_cookbook}::config")
-  end
+    it 'installs the chef_ingredient push-client' do
+      expect(chef_run).to install_chef_ingredient('push-client')
+    end
 
-  it 'starts the opscode-push-jobs-client' do
-    expect(chef_run).to start_runit_service 'opscode-push-jobs-client'
-    expect(chef_run).to enable_runit_service 'opscode-push-jobs-client'
-  end
+    it 'includes the config recipe' do
+      expect(chef_run).to include_recipe("#{described_cookbook}::config")
+    end
 
+    it 'starts the opscode-push-jobs-client' do
+      expect(chef_run).to start_runit_service 'opscode-push-jobs-client'
+      expect(chef_run).to enable_runit_service 'opscode-push-jobs-client'
+    end
+  end
 end


### PR DESCRIPTION
Default behavior on Linux is to install from CHEF's public repositories. Setting the package_url and package_checksum attributes overrides that behavior and is still required on Windows.

WARNING:
Chef Push RPM version <= 1.1.5 fails with  `Package opscode-push-jobs-client-1.1.5-1.el6.x86_64.rpm is not signed ` . Future versions of Chef Push will be properly signed.
