### PR TITLE
Windows push client to use own config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,13 +29,15 @@ default['push_jobs']['environment_variables']       = { 'LC_ALL' => 'en_US.UTF-8
 
 case node['platform_family']
 when 'debian', 'rhel'
-  default['push_jobs']['service_string']            = 'runit_service[opscode-push-jobs-client]'
-  default['push_jobs']['init_style']                = 'runit'
+  default['push_jobs']['service_string']             = 'runit_service[opscode-push-jobs-client]'
+  default['push_jobs']['init_style']                 = 'runit'
+  default['push_jobs']['chef']['client_key_path']    = '/etc/chef/client.pem'
+  default['push_jobs']['chef']['trusted_certs_path'] = '/etc/chef/trusted_certs'
 when 'windows'
-  default['push_jobs']['service_string']            = 'service[pushy-client]'
-  default['push_jobs']['init_style']                = 'windows'
+  default['push_jobs']['service_string']             = 'service[pushy-client]'
+  default['push_jobs']['init_style']                 = 'windows'
+  default['push_jobs']['chef']['client_key_path']    = 'c:\chef\client.pem'
+  default['push_jobs']['chef']['trusted_certs_path'] = 'c:\chef\trusted_certs'
 end
 
-default['push_jobs']['chef']['client_key_path']     = '/etc/chef/client.pem'
-default['push_jobs']['chef']['trusted_certs_path']  = '/etc/chef/trusted_certs'
 default['push_jobs']['chef']['verify_api_cert']     = false

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -23,10 +23,12 @@
 # Do not continue if trying to run the Windows recipe on non-Windows
 raise 'This recipe only supports Windows' unless node['platform_family'] == 'windows'
 
+# Ensure the config is available before installing and starting the service
+include_recipe 'push-jobs::config'
+
 windows_package "Opscode Push Jobs Client Installer for Windows" do
   source node['push_jobs']['package_url']
   checksum node['push_jobs']['package_checksum']
 end
 
-include_recipe 'push-jobs::config'
 include_recipe 'push-jobs::service'

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -9,13 +9,13 @@ describe 'push-jobs::windows' do
     runner.converge('recipe[push-jobs::windows]')
   end
 
+  it 'Includes the config recipe' do
+    expect(chef_run).to include_recipe "#{described_cookbook}::config"
+  end
+
   it 'Installs the MSI file' do
     display_name = 'Opscode Push Jobs Client Installer for Windows'
     expect(chef_run).to install_windows_package "#{display_name}"
-  end
-
-  it 'Includes the config recipe' do
-    expect(chef_run).to include_recipe "#{described_cookbook}::config"
   end
 
   it 'Configures the pushy-client registry key' do

--- a/templates/default/push-jobs-client.rb.erb
+++ b/templates/default/push-jobs-client.rb.erb
@@ -6,8 +6,6 @@
 <%= key %>='<%= value %>'
 <% end %>
 
-#Chef::Config.from_file(PathHelper.join(Chef::Config.platform_specific_path("/etc/chef/"), "client.rb"))
-
 # Chef server connect options
 chef_server_url   '<%= @chef_server_url %>'
 node_name         '<%= @node_name %>'


### PR DESCRIPTION
Partially fixes issue #39.
Remaining task is to create the push msi with the path to the config(c:\chef\push-jobs-client.rb) as part of the 'ImagePath' registry entry.
