### PR TITLE
debug flag to logging level flag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,3 +39,5 @@ end
 default['push_jobs']['chef']['client_key_path']     = '/etc/chef/client.pem'
 default['push_jobs']['chef']['trusted_certs_path']  = '/etc/chef/trusted_certs'
 default['push_jobs']['chef']['verify_api_cert']     = false
+
+default['push_jobs']['logging_level'] = 'info'

--- a/recipes/service_container.rb
+++ b/recipes/service_container.rb
@@ -22,12 +22,10 @@ require 'chef-init'
 require 'chef/provider/container_service'
 require 'chef/resource/container_service'
 
-debug_flag = node[:push_jobs]['debug'] || ":info"
-
 service 'opscode-push-jobs-client' do
   provider Chef::Provider::ContainerService::Runit
 #  options({
-#            :debug => debug_flag,
+#            :logging_level => node['push_jobs']['logging_level'],
 #            :config => PushJobsHelper.config_path
 #          })
   action [:start]

--- a/recipes/service_runit.rb
+++ b/recipes/service_runit.rb
@@ -20,11 +20,9 @@
 
 include_recipe 'runit'
 
-debug_flag = node[:push_jobs]['debug'] || ":info"
-
 runit_service 'opscode-push-jobs-client' do
   options({
-            :debug => debug_flag,
+            :logging_level => node['push_jobs']['logging_level'],
             :config => PushJobsHelper.config_path
           })
   default_logger true

--- a/templates/default/sv-opscode-push-jobs-client-run.erb
+++ b/templates/default/sv-opscode-push-jobs-client-run.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
 exec 2>&1
-exec /opt/opscode-push-jobs-client/bin/pushy-client -l debug -c /etc/chef/push-jobs-client.rb
+exec /opt/opscode-push-jobs-client/bin/pushy-client -l <%= @options[:logging_level] %> -c /etc/chef/push-jobs-client.rb
 
 #exec /opt/opscode-push-jobs-client/bin/pushy-client -l <%= @options[:debug] %> -c <%= @options[:config_path] %>


### PR DESCRIPTION
Hi @someara

Currently the logging is hardcoded to debug which I think is due to the addition of the `service_container` recipe.

Unless I'm mistaken, the `service_container` recipe does not pass template variables, so I removed the unused `debug_flag` variable in the recipe.

TLDR: 

- [x] swap "debug" flag for "logging_level" flag
- [x] logging level is set to `info`
- [x] set `default['push_jobs']['logging_level']` in the attributes, default to `info`
- [x] less spam for all the hearbeats due to `debug` level